### PR TITLE
Exit jenkins master bootstrapping after timeout

### DIFF
--- a/jenkins-master/init.sh
+++ b/jenkins-master/init.sh
@@ -5,8 +5,13 @@ interval=5
 
 while [ ! -d /var/jenkins_home/.git ] || [ ! -f /var/jenkins_home/config.xml ]
 do
-    echo "Checkout not done. Seelping ${interval}s for ${SECONDS}"
-    sleep ${interval}
+    if [ "$SECONDS" -ge "$end_time" ]; then
+        echo "Checkout still not done after ${SECONDS}s. Exiting jenkins master now"
+        exit 1
+    else
+        echo "Checkout not done. Seelping ${interval}s for ${SECONDS}s/${end_time}s"
+        sleep ${interval}
+    fi
 done
 
 /bin/tini -- /usr/local/bin/jenkins.sh


### PR DESCRIPTION
When containers are restarting and somehow the volume could not checkout sources, the master will bootstrap after 3600s a new Jenkins what was the problem in #1 . With this PR the container will exits instead of continuing. 
